### PR TITLE
option callable-types set to falseπ

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@degordian/standards",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Degordian js coding standards",
   "directories": {
     "standards": "standards"

--- a/standards/typescript/tslint/tslint.json
+++ b/standards/typescript/tslint/tslint.json
@@ -6,7 +6,8 @@
   "jsRules": {},
   "rules": {
     "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
-    "interface-name": [true, "never-prefix"]
+    "interface-name": [true, "never-prefix"],
+    "callable-types": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
I suggest setting option callable-types to false, so we can extract function calls to interfaces, instead of having to use types, an example can be found here:

[https://www.typescriptlang.org/docs/handbook/interfaces.html#function-types](https://www.typescriptlang.org/docs/handbook/interfaces.html#function-types)

rule: [https://palantir.github.io/tslint/rules/callable-types/](https://palantir.github.io/tslint/rules/callable-types/)
