### PR TITLE
Removed strict null checks

### DIFF
--- a/standards/typescript/tsconfig/tsconfig.json
+++ b/standards/typescript/tsconfig/tsconfig.json
@@ -10,6 +10,8 @@
     "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "suppressImplicitAnyIndexErrors": true,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": false,
+    "strictNullChecks": false
+    /* Allow class definitions to be null */
   }
 }


### PR DESCRIPTION
Removed strict check for `null`.

We already talked about it, but this is primarily to allow nullable classes.

```js
class A {
    private b : B = null;
}
```

This type of defining is very often and generally acceptable in all strict languages. We want to avoid following type definition:

```js
class A {
    private b : B | null = null;
}
```