### PR TITLE
Disabled object literal sort keys rule

### DIFF
--- a/standards/typescript/tslint/tslint.json
+++ b/standards/typescript/tslint/tslint.json
@@ -6,7 +6,8 @@
   "jsRules": {},
   "rules": {
     "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
-    "interface-name": [true, "never-prefix"]
+    "interface-name": [true, "never-prefix"],
+    "object-literal-sort-keys": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Disabled `"object-literal-sort-keys"` in tslint.json

This closes #14 